### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Student1-441920840385/807e1467-7d84-4a5a-a7d8-12328f4608bf/0bc173eb-a1ac-4826-9f3f-0f46a15ff63e/_apis/work/boardbadge/a2480427-e052-4a1f-955f-d30a15cb588b)](https://dev.azure.com/Student1-441920840385/807e1467-7d84-4a5a-a7d8-12328f4608bf/_boards/board/t/0bc173eb-a1ac-4826-9f3f-0f46a15ff63e/Microsoft.RequirementCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#169](https://dev.azure.com/Student1-441920840385/807e1467-7d84-4a5a-a7d8-12328f4608bf/_workitems/edit/169). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.